### PR TITLE
fix bug 496926

### DIFF
--- a/shell/screenpool.cpp
+++ b/shell/screenpool.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
+#include <QTimer>
 
 #ifndef NDEBUG
 #define CHECK_SCREEN_INVARIANTS screenInvariants();
@@ -277,11 +278,22 @@ void ScreenPool::handleScreenRemoved(QScreen *screen)
     }
 
     // We can't call CHECK_SCREEN_INVARIANTS here, but on handleOutputOrderChanged which is about to arrive
+    QTimer::singleShot(0, this, &ScreenPool::reconsiderOutputOrder);
 }
 
 void ScreenPool::handleOutputOrderChanged(const QStringList &newOrder)
 {
     qCDebug(SCREENPOOL) << "handleOutputOrderChanged" << newOrder;
+    
+    QStringList qtScreenNames;
+    for (auto s : qGuiApp->screens()) {
+        qtScreenNames << s->name();
+    }
+
+    if (QSet<QString>(newOrder.begin(), newOrder.end()) != QSet<QString>(qtScreenNames.begin(), qtScreenNames.end())) {
+        qCDebug(SCREENPOOL) << "Inconsistent screen sets, ignoring screen order change:" << newOrder << qtScreenNames;
+        return;
+    }
 
     QHash<QString, QScreen *> connMap;
     for (auto s : qApp->screens()) {

--- a/shell/screenpool.h
+++ b/shell/screenpool.h
@@ -39,6 +39,9 @@ public:
 Q_SIGNALS:
     void screenRemoved(QScreen *screen); // TODO: necessary?
     void screenOrderChanged(const QList<QScreen *> &screens);
+    
+public Q_SLOTS:
+    void reconsiderOutputOrder(); 
 
 private:
     void insertScreenMapping(int id, const QString &connector);
@@ -46,7 +49,6 @@ private:
 
     QScreen *outputRedundantTo(QScreen *screen) const;
     void reconsiderOutputs();
-    void reconsiderOutputOrder();
     bool isOutputFake(QScreen *screen) const;
 
     void insertSortedScreen(QScreen *screen);


### PR DESCRIPTION
On X11, desktop is black/missing with mouse pointer after resuming from suspend or hibernation or because monitor switch off/on. We introduce a timer to reconsider outputs at the next QT loop, also we filter inconsistent output lists.