### PR TITLE
applets: systemtray: drop xdgActivationToken stuff

### DIFF
--- a/applets/systemtray/statusnotifieritemsource.cpp
+++ b/applets/systemtray/statusnotifieritemsource.cpp
@@ -13,7 +13,6 @@
 #include <KIconColors>
 #include <KIconEngine>
 #include <KIconLoader>
-#include <KWaylandExtras>
 #include <KWindowSystem>
 #include <Plasma/Theme>
 
@@ -57,11 +56,6 @@ protected:
             sendClickedEvent(id);
             return;
         }
-        auto tokenFuture = KWaylandExtras::xdgActivationToken(menu()->window()->windowHandle(), {});
-        tokenFuture.then(m_source, [this, id](const QString &token) {
-            m_source->provideXdgActivationToken(token);
-            sendClickedEvent(id);
-        });
     }
 
 private:
@@ -539,13 +533,6 @@ void StatusNotifierItemSource::contextMenu(int x, int y)
         if (m_statusNotifierItemInterface && m_statusNotifierItemInterface->isValid()) {
             m_statusNotifierItemInterface->call(QDBus::NoBlock, QStringLiteral("ContextMenu"), x, y);
         }
-    }
-}
-
-void StatusNotifierItemSource::provideXdgActivationToken(const QString &token)
-{
-    if (m_statusNotifierItemInterface && m_statusNotifierItemInterface->isValid()) {
-        m_statusNotifierItemInterface->ProvideXdgActivationToken(token);
     }
 }
 

--- a/applets/systemtray/statusnotifieritemsource.h
+++ b/applets/systemtray/statusnotifieritemsource.h
@@ -28,7 +28,6 @@ public:
     void secondaryActivate(int x, int y);
     void scroll(int delta, const QString &direction);
     void contextMenu(int x, int y);
-    void provideXdgActivationToken(const QString &token);
 
     QIcon attentionIcon() const;
     QString attentionIconName() const;

--- a/applets/systemtray/systemtray.cpp
+++ b/applets/systemtray/systemtray.cpp
@@ -35,7 +35,6 @@
 #include <KAcceleratorManager>
 #include <KActionCollection>
 #include <KSharedConfig>
-#include <KWaylandExtras>
 #include <KWindowSystem>
 
 using namespace Qt::StringLiterals;
@@ -427,12 +426,6 @@ void SystemTray::activate(const QString &service, QPoint pos, QQuickItem *status
         source->activate(pos.x(), pos.y());
         return;
     }
-
-    auto tokenFuture = KWaylandExtras::xdgActivationToken(window, {});
-    tokenFuture.then(this, [source, service, pos](const QString &token) {
-        source->provideXdgActivationToken(token);
-        source->activate(pos.x(), pos.y());
-    });
 }
 
 void SystemTray::secondaryActivate(const QString &service, QPoint pos)
@@ -444,12 +437,6 @@ void SystemTray::secondaryActivate(const QString &service, QPoint pos)
         source->secondaryActivate(pos.x(), pos.y());
         return;
     }
-
-    auto tokenFuture = KWaylandExtras::xdgActivationToken(window, {});
-    tokenFuture.then(this, [source, pos](const QString &token) {
-        source->provideXdgActivationToken(token);
-        source->secondaryActivate(pos.x(), pos.y());
-    });
 }
 
 void SystemTray::openContextMenu(const QString &service, QPoint pos, QQuickItem *statusNotifierIcon)
@@ -518,12 +505,6 @@ void SystemTray::openContextMenu(const QString &service, QPoint pos, QQuickItem 
         source->contextMenu(pos.x(), pos.y());
         return;
     }
-
-    auto tokenFuture = KWaylandExtras::xdgActivationToken(window, {});
-    tokenFuture.then(this, [source, pos](const QString &token) {
-        source->provideXdgActivationToken(token);
-        source->contextMenu(pos.x(), pos.y());
-    });
 }
 
 void SystemTray::scroll(const QString &service, int delta, const QString &direction)


### PR DESCRIPTION
It's only needed for Wayland, so we don't need that anymore.