### PR TITLE
applets: drop non-X11s code paths

### DIFF
--- a/applets/kicker/dashboardwindow.cpp
+++ b/applets/kicker/dashboardwindow.cpp
@@ -112,9 +112,7 @@ void DashboardWindow::toggle()
         close();
     } else {
         showFullScreen();
-        if (KWindowSystem::isPlatformX11()) {
-            KX11Extras::forceActiveWindow(winId());
-        }
+        KX11Extras::forceActiveWindow(winId());
     }
 }
 
@@ -124,9 +122,7 @@ bool DashboardWindow::event(QEvent *event)
         const QPlatformSurfaceEvent *pSEvent = static_cast<QPlatformSurfaceEvent *>(event);
 
         if (pSEvent->surfaceEventType() == QPlatformSurfaceEvent::SurfaceCreated) {
-            if (KWindowSystem::isPlatformX11()) {
-                KX11Extras::setState(winId(), NET::SkipTaskbar | NET::SkipPager | NET::SkipSwitcher);
-            }
+            KX11Extras::setState(winId(), NET::SkipTaskbar | NET::SkipPager | NET::SkipSwitcher);
         }
     } else if (event->type() == QEvent::Show) {
         updateTheme();
@@ -138,7 +134,7 @@ bool DashboardWindow::event(QEvent *event)
         if (m_mainItem) {
             m_mainItem->setVisible(false);
         }
-    } else if (event->type() == QEvent::FocusOut && KWindowSystem::isPlatformX11() && isVisible()) {
+    } else if (event->type() == QEvent::FocusOut && isVisible()) {
         KX11Extras::forceActiveWindow(winId());
     }
 

--- a/applets/kicker/windowsystem.cpp
+++ b/applets/kicker/windowsystem.cpp
@@ -31,7 +31,7 @@ bool WindowSystem::eventFilter(QObject *watched, QEvent *event)
 void WindowSystem::forceActive(QQuickItem *item)
 {
     if (item) {
-        if (auto window = item->window(); KWindowSystem::isPlatformX11() && window) {
+        if (auto window = item->window(); window) {
             KX11Extras::forceActiveWindow(window->winId());
         }
     }

--- a/applets/systemtray/statusnotifieritemsource.cpp
+++ b/applets/systemtray/statusnotifieritemsource.cpp
@@ -52,10 +52,7 @@ protected:
 
     void actionActivated(int id) override
     {
-        if (KWindowSystem::isPlatformX11() || !menu()->window() || !menu()->window()->windowHandle()) {
-            sendClickedEvent(id);
-            return;
-        }
+        sendClickedEvent(id);
     }
 
 private:

--- a/applets/systemtray/systemtray.cpp
+++ b/applets/systemtray/systemtray.cpp
@@ -249,7 +249,7 @@ QPointF SystemTray::popupPosition(QQuickItem *visualParent, int x, int y)
     QQuickWindow *const window = visualParent->window();
     if (window && window->screen()) {
         pos = window->mapToGlobal(pos.toPoint());
-        if (KWindowSystem::isPlatformX11()) {
+        {
             const auto devicePixelRatio = window->screen()->devicePixelRatio();
             if (QGuiApplication::screens().size() == 1) {
                 return pos * devicePixelRatio;
@@ -420,10 +420,7 @@ void SystemTray::activate(const QString &service, QPoint pos, QQuickItem *status
         Qt::SingleShotConnection);
 
     QWindow *window = nullptr;
-    if (KWindowSystem::isPlatformX11()) {
-        source->activate(pos.x(), pos.y());
-        return;
-    }
+    source->activate(pos.x(), pos.y());
 }
 
 void SystemTray::secondaryActivate(const QString &service, QPoint pos)
@@ -431,10 +428,7 @@ void SystemTray::secondaryActivate(const QString &service, QPoint pos)
     const auto source = StatusNotifierItemHost::self()->itemForService(service);
 
     QWindow *window = nullptr;
-    if (KWindowSystem::isPlatformX11()) {
-        source->secondaryActivate(pos.x(), pos.y());
-        return;
-    }
+    source->secondaryActivate(pos.x(), pos.y());
 }
 
 void SystemTray::openContextMenu(const QString &service, QPoint pos, QQuickItem *statusNotifierIcon)
@@ -499,10 +493,7 @@ void SystemTray::openContextMenu(const QString &service, QPoint pos, QQuickItem 
         Qt::SingleShotConnection);
 
     QWindow *window = nullptr;
-    if (KWindowSystem::isPlatformX11()) {
-        source->contextMenu(pos.x(), pos.y());
-        return;
-    }
+    source->contextMenu(pos.x(), pos.y());
 }
 
 void SystemTray::scroll(const QString &service, int delta, const QString &direction)


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.