### PR TITLE
libkworkspace: drop non-X11 code paths

### DIFF
--- a/libtaskmanager/autotests/common.h
+++ b/libtaskmanager/autotests/common.h
@@ -326,9 +326,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleMinimized(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -340,9 +338,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestActivate(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -354,9 +350,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleMaximized(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -366,9 +360,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleMaximized(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -381,9 +373,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleKeepAbove(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -396,9 +386,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleKeepBelow(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -408,9 +396,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleKeepBelow(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -423,9 +409,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleFullScreen(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -434,23 +418,19 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleFullScreen(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
         QTRY_VERIFY(!index.data(AbstractTasksModel::IsFullScreen).toBool());
     }
 
-    if (KWindowSystem::isPlatformX11()) {
+    {
         qDebug("requestToggleShaded");
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleShaded(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -459,9 +439,7 @@ void testRequest(AbstractWindowTasksModel &model)
         QCoreApplication::processEvents();
         dataChangedSpy.clear();
         model.requestToggleShaded(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (dataChangedSpy.empty()) {
             QVERIFY(dataChangedSpy.wait(timeout));
         }
@@ -472,9 +450,7 @@ void testRequest(AbstractWindowTasksModel &model)
     {
         qDebug("requestClose");
         model.requestClose(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (rowsRemovedSpy.empty()) {
             QVERIFY(rowsRemovedSpy.wait(timeout));
         }
@@ -485,9 +461,7 @@ void testRequest(AbstractWindowTasksModel &model)
         findWindowIndex(index, QStringLiteral("__test_window_no_title__"));
         rowsRemovedSpy.clear();
         model.requestClose(index);
-        if (KWindowSystem::isPlatformX11()) {
-            QX11Info::getTimestamp(); // roundtrip
-        }
+        QX11Info::getTimestamp(); // roundtrip
         if (rowsRemovedSpy.empty()) {
             QVERIFY(rowsRemovedSpy.wait(timeout));
         }

--- a/libtaskmanager/autotests/xwindowtasksmodeltest.cpp
+++ b/libtaskmanager/autotests/xwindowtasksmodeltest.cpp
@@ -58,9 +58,6 @@ private:
 void XWindowTasksModelTest::initTestCase()
 {
     TestUtils::initTestCase();
-    if (!KWindowSystem::isPlatformX11()) {
-        QSKIP("Test is not running on X11.");
-    }
 
     char *singleWIdData = new char[sizeof(WId)];
     memcpy(singleWIdData, &m_WId, sizeof(WId));

--- a/libtaskmanager/startuptasksmodel.cpp
+++ b/libtaskmanager/startuptasksmodel.cpp
@@ -50,7 +50,7 @@ StartupTasksModel::Private::~Private()
 
 void StartupTasksModel::Private::initSourceTasksModel()
 {
-    if (!sourceTasksModel && KWindowSystem::isPlatformX11()) {
+    if (!sourceTasksModel) {
         sourceTasksModel = new XStartupTasksModel();
     }
 

--- a/libtaskmanager/taskfilterproxymodel.cpp
+++ b/libtaskmanager/taskfilterproxymodel.cpp
@@ -12,7 +12,6 @@
 #include "config-X11.h"
 #include <QGuiApplication>
 #include <QScreen>
-
 #include <KWindowSystem>
 
 namespace TaskManager
@@ -361,7 +360,7 @@ bool TaskFilterProxyModel::acceptsRow(int sourceRow) const
         QRect windowGeometry = sourceIdx.data(AbstractTasksModel::Geometry).toRect();
 
         QRect regionGeometry = d->regionGeometry;
-        if (static const bool isX11 = KWindowSystem::isPlatformX11(); isX11 && windowGeometry.isValid()) {
+        if (windowGeometry.isValid()) {
             // On X11, in regionGeometry, the original point of the topLeft position belongs to the device coordinate system
             // but the size belongs to the logical coordinate system (which means the reported size is already divided by DPR)
             // Converting regionGeometry to device coordinate system is better than converting windowGeometry to logical

--- a/libtaskmanager/windowtasksmodel.cpp
+++ b/libtaskmanager/windowtasksmodel.cpp
@@ -49,9 +49,7 @@ WindowTasksModel::Private::~Private()
 
 void WindowTasksModel::Private::initSourceTasksModel()
 {
-    if (!sourceTasksModel && KWindowSystem::isPlatformX11()) {
-        sourceTasksModel = new XWindowTasksModel();
-    }
+    sourceTasksModel = new XWindowTasksModel();
 
     q->setSourceModel(sourceTasksModel);
 }


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.