### PR TITLE
appmenu: drop non-X11 code paths

### DIFF
--- a/appmenu/menuimporter.cpp
+++ b/appmenu/menuimporter.cpp
@@ -50,7 +50,7 @@ void MenuImporter::RegisterWindow(WId id, const QDBusObjectPath &path)
     if (path.path().isEmpty()) // prevent bad dbusmenu usage
         return;
 
-    if (KWindowSystem::isPlatformX11()) {
+    {
         KWindowInfo info(id, NET::WMWindowType, NET::WM2WindowClass);
         NET::WindowTypes mask = NET::AllTypesMask;
         auto type = info.windowType(mask);


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.