### PR TITLE
gmenu-dbusmenu-proxy: drop non-X11 code paths

### DIFF
--- a/gmenu-dbusmenu-proxy/main.cpp
+++ b/gmenu-dbusmenu-proxy/main.cpp
@@ -25,10 +25,6 @@ int main(int argc, char **argv)
 
     QGuiApplication app(argc, argv);
 
-    if (!KWindowSystem::isPlatformX11()) {
-        qFatal("gmenudbusmenuproxy is only useful XCB. Aborting");
-    }
-
     KAboutData about(QStringLiteral("gmenudbusmenuproxy"), QString(), QStringLiteral(WORKSPACE_VERSION_STRING));
     KAboutData::setApplicationData(about);
 

--- a/gmenu-dbusmenu-proxy/menuproxy.cpp
+++ b/gmenu-dbusmenu-proxy/menuproxy.cpp
@@ -269,7 +269,7 @@ void MenuProxy::onWindowAdded(WId id)
         return;
     }
 
-    if (KWindowSystem::isPlatformX11()) {
+    {
         KWindowInfo info(id, NET::WMWindowType);
 
         NET::WindowType wType = info.windowType(NET::NormalMask | NET::DesktopMask | NET::DockMask | NET::ToolbarMask | NET::MenuMask | NET::DialogMask


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.