### PR TITLE
kcms: drop non-X11 code paths

### DIFF
--- a/kcms/colors/colors.cpp
+++ b/kcms/colors/colors.cpp
@@ -372,9 +372,7 @@ void KCMColors::editScheme(const QString &schemeName, QQuickItem *ctx)
         // However, since we pass the ID to an external process which has no idea of this
         // we need to resolve the actual window we end up showing in.
         if (QWindow *actualWindow = QQuickRenderControl::renderWindowFor(ctx->window())) {
-            if (KWindowSystem::isPlatformX11()) {
                 args << QStringLiteral("--attach") << QString::number(actualWindow->winId());
-            }
         }
     }
 

--- a/kcms/cursortheme/xcursor/cursortheme.cpp
+++ b/kcms/cursortheme/xcursor/cursortheme.cpp
@@ -122,9 +122,6 @@ bool CursorTheme::haveXfixes()
     bool result = false;
 
 #ifdef HAVE_XFIXES
-    if (!QX11Info::isPlatformX11()) {
-        return result;
-    }
     int event_base, error_base;
     if (XFixesQueryExtension(QX11Info::display(), &event_base, &error_base)) {
         int major, minor;

--- a/kcms/cursortheme/xcursor/previewwidget.cpp
+++ b/kcms/cursortheme/xcursor/previewwidget.cpp
@@ -219,9 +219,7 @@ void PreviewWidget::layoutItems()
 {
     if (!list.isEmpty()) {
         double deviceCoordinateWidth = width();
-        if (KWindowSystem::isPlatformX11()) {
-            deviceCoordinateWidth *= window()->devicePixelRatio();
-        }
+        deviceCoordinateWidth *= window()->devicePixelRatio();
         const int spacing = cursorSpacing / 2;
         int nextX = spacing;
         int nextY = spacing;
@@ -269,9 +267,7 @@ void PreviewWidget::paint(QPainter *painter)
     // as they will be rendered by X11/KWin, ignoring whatever Qt
     // scaling
     double devicePixelRatio = 1;
-    if (KWindowSystem::isPlatformX11()) {
-        devicePixelRatio = window()->devicePixelRatio();
-    }
+    devicePixelRatio = window()->devicePixelRatio();
     painter->scale(1 / devicePixelRatio, 1 / devicePixelRatio);
     for (const auto *c : std::as_const(list)) {
         if (c->pixmap().isNull())
@@ -289,9 +285,7 @@ void PreviewWidget::hoverMoveEvent(QHoverEvent *e)
         layoutItems();
 
     double devicePixelRatio = 1.0;
-    if (KWindowSystem::isPlatformX11()) {
-        devicePixelRatio = window()->devicePixelRatio();
-    }
+    devicePixelRatio = window()->devicePixelRatio();
     auto it = std::ranges::find_if(list, [e, devicePixelRatio](const PreviewCursor *c) {
         return c->rect().contains(e->position() * devicePixelRatio);
     });

--- a/kcms/fonts/fonts.cpp
+++ b/kcms/fonts/fonts.cpp
@@ -114,7 +114,7 @@ void KFonts::save()
 {
     bool forceFontDPIChanged = false;
 
-    if (KWindowSystem::isPlatformX11()) {
+    {
         auto dpiItem = fontsAASettings()->findItem(u"forceFontDPI"_s);
         auto antiAliasingItem = fontsAASettings()->findItem(u"antiAliasing"_s);
         Q_ASSERT(dpiItem && antiAliasingItem);
@@ -129,7 +129,7 @@ void KFonts::save()
 
     // if the setting is reset in the module, remove the dpi value,
     // otherwise don't explicitly remove it and leave any possible system-wide value
-    if (fontsAASettings()->forceFontDPI() == 0 && forceFontDPIChanged && KWindowSystem::isPlatformX11()) {
+    if (fontsAASettings()->forceFontDPI() == 0 && forceFontDPIChanged) {
         QProcess proc;
         proc.setProcessChannelMode(QProcess::ForwardedChannels);
         proc.start(u"xrdb"_s, QStringList{u"-quiet"_s, u"-remove"_s, u"-nocpp"_s});

--- a/kcms/kfontinst/apps/CreateParent.h
+++ b/kcms/kfontinst/apps/CreateParent.h
@@ -17,10 +17,6 @@
 // for xid, and all other widgets can use this as their parent...
 static QWidget *createParent(int xid)
 {
-    if (!QX11Info::isPlatformX11()) {
-        return nullptr;
-    }
-
     if (!xid)
         return nullptr;
 

--- a/kcms/kfontinst/lib/FcEngine.cpp
+++ b/kcms/kfontinst/lib/FcEngine.cpp
@@ -36,11 +36,7 @@ static Display *xDisplay()
 {
     static Display *s_display = nullptr;
     if (!s_display) {
-        if (QX11Info::isPlatformX11()) {
             s_display = QX11Info::display();
-        } else {
-            s_display = XOpenDisplay(NULL); // TODO close it again
-        }
     }
     return s_display;
 }


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.