### PR TITLE
ksplash: drop non-X11 code paths

### DIFF
--- a/ksplash/ksplashqml/splashwindow.cpp
+++ b/ksplash/ksplashqml/splashwindow.cpp
@@ -45,13 +45,8 @@ SplashWindow::SplashWindow(bool testing, bool window, const QString &theme, QScr
     }
 
     if (!m_testing && !m_window) {
-        if (KWindowSystem::isPlatformX11()) {
-            // X11 specific hint only on X11
-            setFlags(Qt::BypassWindowManagerHint);
-        } else {
-            // on other platforms go fullscreen
-            setWindowState(Qt::WindowFullScreen);
-        }
+        // X11 specific hint only on X11
+        setFlags(Qt::BypassWindowManagerHint);
     }
 
     if (m_testing && !m_window) {


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.