### PR TITLE
xembed-sni-proxy: drop non-X11 code paths

### DIFF
--- a/xembed-sni-proxy/main.cpp
+++ b/xembed-sni-proxy/main.cpp
@@ -47,10 +47,6 @@ int main(int argc, char **argv)
 
     QGuiApplication app(argc, argv);
 
-    if (!KWindowSystem::isPlatformX11()) {
-        qFatal("xembed-sni-proxy is only useful XCB. Aborting");
-    }
-
     KAboutData about(QStringLiteral("xembedsniproxy"), QString(), QStringLiteral(WORKSPACE_VERSION_STRING));
     KAboutData::setApplicationData(about);
 


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.