### PR TITLE
soliduiserver: drop non-X11 code paths

### DIFF
--- a/soliduiserver/soliduiserver.cpp
+++ b/soliduiserver/soliduiserver.cpp
@@ -145,7 +145,7 @@ void SolidUiServer::reparentDialog(QWidget *dialog, WId wId, const QString &appI
     dialog->setAttribute(Qt::WA_NativeWindow, true);
     KWindowSystem::setMainWindow(dialog->windowHandle(), wId); // correct, set dialog parent
 
-    if (KWindowSystem::isPlatformX11()) {
+    {
         if (modal) {
             KX11Extras::setState(dialog->winId(), NET::Modal);
         } else {


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.