### PR TITLE
shell: drop non-X11 code paths

### DIFF
--- a/shell/panelconfigview.cpp
+++ b/shell/panelconfigview.cpp
@@ -78,7 +78,7 @@ void PanelRulerView::syncPanelLocation()
         setBorders(Qt::TopEdge);
     }
 
-    if (KWindowSystem::isPlatformX11()) {
+    {
         KX11Extras::setType(winId(), NET::Dock);
         KX11Extras::setState(winId(), NET::KeepAbove);
 
@@ -110,66 +110,6 @@ void PanelRulerView::syncPanelLocation()
         default:
             setPosition(available.bottomLeft() + screen->geometry().topLeft() - QPoint(0, height()));
         }
-    } else if (m_layerWindow) {
-        switch (m_containment->location()) {
-        case Plasma::Types::LeftEdge:
-        case Plasma::Types::RightEdge:
-            m_layerWindow->setDesiredSize(QSize(mainItem()->implicitWidth(), available.height()));
-            break;
-        case Plasma::Types::TopEdge:
-        case Plasma::Types::BottomEdge:
-        default:
-            m_layerWindow->setDesiredSize(QSize(available.width(), mainItem()->implicitHeight()));
-            break;
-        }
-
-        m_layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
-        LayerShellQt::Window::Anchors anchors;
-
-        switch (m_containment->location()) {
-        case Plasma::Types::TopEdge:
-            anchors.setFlag(LayerShellQt::Window::AnchorTop);
-            break;
-        case Plasma::Types::LeftEdge:
-            anchors.setFlag(LayerShellQt::Window::AnchorLeft);
-            break;
-        case Plasma::Types::RightEdge:
-            anchors.setFlag(LayerShellQt::Window::AnchorRight);
-            break;
-        case Plasma::Types::BottomEdge:
-        default:
-            anchors.setFlag(LayerShellQt::Window::AnchorBottom);
-            break;
-        }
-
-        if (m_containment->formFactor() == Plasma::Types::Horizontal) {
-            switch (m_panelView->alignment()) {
-            case Qt::AlignLeft:
-                anchors.setFlag(LayerShellQt::Window::AnchorLeft);
-                break;
-            case Qt::AlignCenter:
-                break;
-            case Qt::AlignRight:
-                anchors.setFlag(LayerShellQt::Window::AnchorRight);
-                break;
-            }
-        } else {
-            switch (m_panelView->alignment()) {
-            case Qt::AlignLeft:
-                anchors.setFlag(LayerShellQt::Window::AnchorTop);
-                break;
-            case Qt::AlignCenter:
-                break;
-            case Qt::AlignRight:
-                anchors.setFlag(LayerShellQt::Window::AnchorBottom);
-                break;
-            }
-        }
-
-        // m_layerWindow->setMargins(margins);
-        m_layerWindow->setAnchors(anchors);
-
-        requestUpdate();
     }
 }
 

--- a/shell/panelshadows.cpp
+++ b/shell/panelshadows.cpp
@@ -238,9 +238,7 @@ void PanelShadows::Private::updateShadow(QWindow *window, KSvg::FrameSvg::Enable
     QMargins padding;
     QMargins extraPadding = m_extraPadding.value(window);
 
-    if (KWindowSystem::isPlatformX11()) {
-        extraPadding *= window->devicePixelRatio();
-    }
+    extraPadding *= window->devicePixelRatio();
 
     if (enabledBorders & KSvg::FrameSvg::TopBorder) {
         const QSize marginHint = q->elementSize(QStringLiteral("shadow-hint-top-margin")).toSize();

--- a/shell/panelview.cpp
+++ b/shell/panelview.cpp
@@ -151,8 +151,7 @@ bool PanelView::isUnsupportedEnvironment() const
     // It is a static variable: compute it once and cache the results because
     // we don't expect such configuration to change at runtime.
     static const bool unsupported = []() {
-        const auto isX11 = KWindowSystem::isPlatformX11();
-        return isX11 && vendorIsNVidia();
+        return vendorIsNVidia();
     }();
     return unsupported;
 }
@@ -1104,7 +1103,7 @@ void PanelView::keyPressEvent(QKeyEvent *event)
 void PanelView::integrateScreen()
 {
     updateMask();
-    if (KWindowSystem::isPlatformX11()) {
+    {
         KX11Extras::setOnAllDesktops(winId(), true);
         KX11Extras::setType(winId(), NET::Dock);
         if (auto xcbWindow = nativeInterface<QNativeInterface::Private::QXcbWindow>()) {
@@ -1446,7 +1445,7 @@ void PanelView::updateMask()
                                                  mask);
     }
 
-    if (!KWindowSystem::isPlatformX11() || KX11Extras::compositingActive()) {
+    if (KX11Extras::compositingActive()) {
         const QRect bounding = mask.boundingRect();
         // Always go to screen edge, to preserve fitts law
         switch (containment()->location()) {
@@ -1473,9 +1472,6 @@ void PanelView::updateMask()
 
 bool PanelView::canSetStrut() const
 {
-    if (!KWindowSystem::isPlatformX11()) {
-        return true;
-    }
     // read the wm name, need to do this every time which means a roundtrip unfortunately
     // but WM might have changed
     NETRootInfo rootInfo(qGuiApp->nativeInterface<QNativeInterface::QX11Application>()->connection(), NET::Supported | NET::SupportingWMCheck);
@@ -1750,9 +1746,7 @@ void PanelView::refreshStatus(Plasma::Types::ItemStatus status)
     if (status == Plasma::Types::NeedsAttentionStatus) {
         showTemporarily();
         setFlags(flags() | Qt::WindowDoesNotAcceptFocus);
-        if (KWindowSystem::isPlatformX11()) {
-            KX11Extras::setState(winId(), NET::SkipSwitcher | NET::KeepAbove);
-        }
+        KX11Extras::setState(winId(), NET::SkipSwitcher | NET::KeepAbove);
         if (m_layerWindow) {
             m_layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityNone);
             requestUpdate();
@@ -1760,11 +1754,7 @@ void PanelView::refreshStatus(Plasma::Types::ItemStatus status)
     } else if (status == Plasma::Types::AcceptingInputStatus) {
         m_corona->savePreviousWindow();
         setFlags(flags() & ~Qt::WindowDoesNotAcceptFocus);
-        if (KWindowSystem::isPlatformX11()) {
-            KX11Extras::forceActiveWindow(winId());
-        } else {
-            showTemporarily();
-        }
+        KX11Extras::forceActiveWindow(winId());
 
         if (m_layerWindow) {
             m_layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
@@ -1786,9 +1776,7 @@ void PanelView::refreshStatus(Plasma::Types::ItemStatus status)
 
         restoreAutoHide();
         setFlags(flags() | Qt::WindowDoesNotAcceptFocus);
-        if (KWindowSystem::isPlatformX11()) {
-            KX11Extras::setState(winId(), NET::SkipSwitcher | NET::KeepAbove);
-        }
+        KX11Extras::setState(winId(), NET::SkipSwitcher | NET::KeepAbove);
         if (m_layerWindow) {
             m_layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityNone);
             requestUpdate();

--- a/shell/screenpool.cpp
+++ b/shell/screenpool.cpp
@@ -253,7 +253,6 @@ void ScreenPool::handleScreenRemoved(QScreen *screen)
         m_fakeScreens.remove(screen);
     } else if (isOutputFake(screen)) {
         // Fake but not in m_fakeScreens can only happen on X11, where the last output quietly renames itself to ":0.0" without signals
-        Q_ASSERT(KWindowSystem::isPlatformX11());
         Q_ASSERT(!m_redundantScreens.contains(screen));
         Q_ASSERT(!m_fakeScreens.contains(screen));
         m_availableScreens.removeAll(screen);


### PR DESCRIPTION
We're always on X11, so no non-X11 code pathes necessary.