### PR TITLE
CMakeLists.txt: fix dependency version of Plasma and PlasmaQuick

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,8 @@ find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS
                     Notifications Package Parts Prison Runner StatusNotifierItem
                     Svg TextEditor TextWidgets Wallet ColorScheme
                     OPTIONAL_COMPONENTS DocTools)
-find_package(Plasma ${PROJECT_DEP_VERSION} REQUIRED)
-find_package(PlasmaQuick ${PROJECT_DEP_VERSION} REQUIRED)
+find_package(Plasma 6.6.2 REQUIRED)
+find_package(PlasmaQuick 6.6.2 REQUIRED)
 find_package(PlasmaActivities ${PROJECT_DEP_VERSION} REQUIRED)
 find_package(PlasmaActivitiesStats ${PROJECT_DEP_VERSION} REQUIRED)
 find_package(KSysGuard ${PROJECT_DEP_VERSION} CONFIG)


### PR DESCRIPTION
We don't have 6.6.3 yet, and 6.6.2 is sufficient here.