### PR TITLE
appmenu: drop obsolete AppMenuModule::ensureSerial()

### DIFF
--- a/appmenu/appmenu.cpp
+++ b/appmenu/appmenu.cpp
@@ -207,10 +207,6 @@ void AppMenuModule::reconfigure()
 {
 }
 
-void AppMenuModule::ensureSerial(QWindow *w)
-{
-}
-
 #include "appmenu.moc"
 
 #include "moc_appmenu.cpp"

--- a/appmenu/appmenu.h
+++ b/appmenu/appmenu.h
@@ -66,7 +66,6 @@ private Q_SLOTS:
 
 private:
     void hideMenu();
-    void ensureSerial(QWindow *window);
 
     void fakeUnityAboutToShow(const QString &service, const QDBusObjectPath &menuObjectPath);
 


### PR DESCRIPTION
Empty and not called by anybody, so not needed anymore at all.