### PR TITLE
kcms: kfontinst: fix fontconfig.h include order

### DIFF
--- a/kcms/kfontinst/lib/Fc.h
+++ b/kcms/kfontinst/lib/Fc.h
@@ -8,8 +8,8 @@
 #include "Misc.h"
 #include "kfontinst_export.h"
 #include <QUrl>
-#include <fontconfig/fcfreetype.h>
 #include <fontconfig/fontconfig.h>
+#include <fontconfig/fcfreetype.h>
 
 #include "kfontinst_export.h"
 


### PR DESCRIPTION
fontconfig.h must be included first, otherwise some types aren't defined yet.